### PR TITLE
report cURL errors

### DIFF
--- a/lib/ServerPilot.php
+++ b/lib/ServerPilot.php
@@ -333,6 +333,11 @@ class ServerPilot {
 		$response = curl_exec( $req );
 		$http_status = curl_getinfo( $req, CURLINFO_HTTP_CODE );
 
+		if ($response === FALSE) {
+			$curl_error = curl_error( $req );
+			throw new Exception( $curl_error );
+		}
+
 		curl_close( $req );
 
 		// Decode JSON by default


### PR DESCRIPTION
there are a number of reasons why cURL requests can fail. A pretty common one is related to SSL certificates, e.g. `SSL certificate problem: self signed certificate in certificate chain`.

I suggest to throw them as exceptions so that dev at least know about them without having to debug the code.